### PR TITLE
fixed bug on BlueHost where welcome.php was cut off

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -4,7 +4,7 @@ $conn = false;
 
 function getConfigData()
 {
-	$path = 'db/config.json';
+	$path = realpath(dirname(dirname(__FILE__))) . str_replace('/', DIRECTORY_SEPARATOR, '/db/config.json');
 	return json_decode(file_get_contents($path));
 }
 


### PR DESCRIPTION
The problem was that the path was calculated as public_html/db/config.json
instead of public_html/cognizance/db/config.json.  Using __FILE__ made
the path relative to the config.php position which would be the same in
local or on BlueHost.

Related to #11